### PR TITLE
Corrects reference to options.start

### DIFF
--- a/js/photostack.js
+++ b/js/photostack.js
@@ -95,7 +95,7 @@
 		this.options = extend( {}, this.options );
   	extend( this.options, options );
  		// index of the current photo
-		this.current = options.start;
+		this.current = this.options.start;
   	this._init();
 		var ps = this;
 


### PR DESCRIPTION
If PS was initialized with no default start option, an error was thrown
that prevented PS from loading correctly.
